### PR TITLE
Add mandatory branching workflow guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,34 @@ pip install -r requirements.txt
 pip install black flake8 pytest pytest-cov
 ```
 
+### Git Workflow - IMPORTANT
+**NEVER push directly to main/master branch.** Always use feature branches:
+
+```bash
+# 1. Create and switch to feature branch
+git checkout -b feature/your-feature-name
+# or for fixes: git checkout -b fix/issue-description
+
+# 2. Make your changes and commits on the branch
+
+# 3. Push feature branch
+git push -u origin feature/your-feature-name
+
+# 4. Create Pull Request via GitHub CLI or web interface
+gh pr create --title "Description of changes" --body "Detailed explanation"
+
+# 5. After PR is merged, clean up
+git checkout main
+git pull origin main
+git branch -d feature/your-feature-name
+```
+
+**Branch Naming Convention:**
+- `feature/add-custom-fields` - New functionality
+- `fix/datetime-comparison-bug` - Bug fixes  
+- `docs/improve-readme` - Documentation updates
+- `refactor/validation-functions` - Code refactoring
+
 ### IMPORTANT: Always Run Before Committing
 After making code changes, always run these commands locally to avoid CI failures:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,9 +88,21 @@ For new features:
 
 #### Pull Request Process
 
-1. **Branch naming**: Use descriptive names like `fix-date-validation` or `add-custom-fields`
+1. **NEVER push directly to main**: Always create feature branches
+   ```bash
+   git checkout -b feature/your-feature-name
+   # Make changes, test, commit
+   git push -u origin feature/your-feature-name
+   gh pr create --title "Your change description"
+   ```
 
-2. **Commit messages**: Use clear, descriptive commit messages
+2. **Branch naming**: Use descriptive names with prefixes:
+   - `feature/add-custom-fields` - New functionality
+   - `fix/datetime-bug` - Bug fixes
+   - `docs/update-readme` - Documentation
+   - `refactor/validation` - Code improvements
+
+3. **Commit messages**: Use clear, descriptive commit messages
    ```
    Add validation for ticket format
    


### PR DESCRIPTION
## Summary
Establishes proper Git workflow to prevent direct pushes to main branch.

## Changes
- Add "NEVER push directly to main" guidelines to CLAUDE.md
- Include step-by-step feature branch workflow
- Define branch naming conventions (feature/, fix/, docs/, refactor/)  
- Update CONTRIBUTING.md with same requirements
- Demonstrate proper PR workflow for all future changes

## Why This Matters
Direct pushes to main bypass:
- Code review process
- CI validation on branches
- Proper change tracking
- Collaborative development practices

## Testing
- [x] Documentation is clear and actionable
- [x] Examples follow established patterns
- [x] Workflow is properly demonstrated

This PR itself demonstrates the correct workflow that should be followed going forward.